### PR TITLE
R merged closed metrics

### DIFF
--- a/analysis/plumber.R
+++ b/analysis/plumber.R
@@ -99,7 +99,7 @@ function(req) {
   payload <- req$body %>% as.data.table()
   payload %>%
     select(created_at, merged_at, closed_at) %>% 
-    filter(is.na(closed_at) & is.na(merged_at) & !is.na(merged_at)) %>%
+    filter(is.na(closed_at) & is.na(merged_at)) %>%
     mutate(
       created_at = lubridate::ymd_hms(created_at),
       merged_at = lubridate::ymd_hms(merged_at),


### PR DESCRIPTION
light fixes for the last30_total/init commit of merged_closed_age function which returns the median and average age of merged and closed PRs for the year and compares against the current (last 30 days) median and average and finds the diff, all measured in days