### PR TITLE
Hero fixes

### DIFF
--- a/analysis/plumber.R
+++ b/analysis/plumber.R
@@ -205,5 +205,3 @@ function(req) {
                            paste0('(', round(100*store$change,1), '%)'))))
   return(out)
 }
-
-test$closed_at %>% summary


### PR DESCRIPTION
Hero fixes are go. Couldn't find anything necessarily wrong with the closed_at function though, just ensure we are inputting the passed 60 days at least (ideally the passed year for annual comparison) of created_at and closed_at values, NaN checks are also in place.