### PR TITLE
Better handling of job scheduling

### DIFF
--- a/server/lib/astoria/github/api/client.ex
+++ b/server/lib/astoria/github/api/client.ex
@@ -5,7 +5,7 @@ defmodule Astoria.Github.Api.Client do
   defstruct [:token, :type]
 
   @doc ~S"""
-  Exchanges a Github code for access and refresh tokens
+  Builds a client token suitable for Github access
 
   ## Examples
 

--- a/server/lib/astoria/github_installation_authorizations/github_installation_authorization.ex
+++ b/server/lib/astoria/github_installation_authorizations/github_installation_authorization.ex
@@ -7,6 +7,7 @@ defmodule Astoria.GithubInstallationAuthorizations.GithubInstallationAuthorizati
     belongs_to :github_installation, GithubInstallations.GithubInstallation
     field :data, :map
     field :expires_at, :utc_datetime
+    field :rate_limit_last_updated_at, :utc_datetime
     field :rate_limit_remaining, :integer
     field :rate_limit_resets_at, :utc_datetime
     field :token, :string
@@ -22,6 +23,7 @@ defmodule Astoria.GithubInstallationAuthorizations.GithubInstallationAuthorizati
       :github_installation_id,
       :rate_limit_remaining,
       :rate_limit_resets_at,
+      :rate_limit_last_updated_at,
       :token
     ])
     |> validate_required([

--- a/server/lib/astoria/github_installations/github_repositories.ex
+++ b/server/lib/astoria/github_installations/github_repositories.ex
@@ -14,25 +14,33 @@ defmodule Astoria.GithubInstallations.GithubRepositories do
   def sync(github_installation) do
     case GithubInstallations.client(github_installation) do
       {:ok, client} ->
-        github_installation =
-          Repo.preload(github_installation, :github_installation_authorization)
-
-        github_installation_authorization = github_installation.github_installation_authorization
-
         request = Github.Api.V3.Installation.Repositories.read(client)
 
         payload = %{
           callback: &sync_callback/2,
-          github_installation_authorization_id: github_installation_authorization.id,
           github_installation_id: github_installation.id,
           request: request
         }
 
         Jobs.GithubSync.InstallationAuthorizedRequest.enqueue(
-          github_installation_authorization,
+          github_installation,
           payload
         )
     end
+  end
+
+  @doc """
+  Updates details on repositories and launchs a sync of pull requests
+  """
+  def sync_callback(%{github_installation_id: github_installation_id}, response) do
+    github_installation = Repo.get(GithubInstallations.GithubInstallation, github_installation_id)
+
+    Enum.map(response.poison_response.body["repositories"], fn repository ->
+      case GithubInstallations.GithubRepositories.upsert(github_installation, repository) do
+        {:ok, github_repository} ->
+          GithubRepositories.GithubPullRequests.sync(github_repository)
+      end
+    end)
   end
 
   @doc """
@@ -50,19 +58,5 @@ defmodule Astoria.GithubInstallations.GithubRepositories do
       on_conflict: {:replace_all_except, [:id, :pub_id]},
       conflict_target: :github_id
     )
-  end
-
-  @doc """
-  Updates details on repositories and launchs a sync of pull requests
-  """
-  def sync_callback(%{github_installation_id: github_installation_id}, response) do
-    github_installation = Repo.get(GithubInstallations.GithubInstallation, github_installation_id)
-
-    Enum.map(response.poison_response.body["repositories"], fn repository ->
-      case GithubInstallations.GithubRepositories.upsert(github_installation, repository) do
-        {:ok, github_repository} ->
-          GithubRepositories.GithubPullRequests.sync(github_repository)
-      end
-    end)
   end
 end

--- a/server/priv/repo/migrations/20201227104363_rate_limit_last_updated.exs
+++ b/server/priv/repo/migrations/20201227104363_rate_limit_last_updated.exs
@@ -1,0 +1,9 @@
+defmodule Astoria.Repo.Migrations.RateLimitLastUpdated do
+  use Ecto.Migration
+
+  def change do
+    alter table(:github_installation_authorizations) do
+      add :rate_limit_last_updated_at, :utc_datetime
+    end
+  end
+end

--- a/server/test/astoria/jobs/github_sync/installation_authorized_request_test.exs
+++ b/server/test/astoria/jobs/github_sync/installation_authorized_request_test.exs
@@ -12,13 +12,30 @@ defmodule Astoria.Jobs.GithubSync.InstallationAuthorizedRequestTest do
   def callback(_params, _response) do
   end
 
+  test "enqueue/2" do
+    github_installation = insert(:github_installation)
+
+    HTTPoisonMock
+    |> expect(:post, fn _path, _payload, _headers ->
+      {:ok, Fixtures.Github.Api.V3.App.Installations.AccessTokens.create()}
+    end)
+
+    payload = %{"hello" => "world"}
+
+    assert {:ok, job} = InstallationAuthorizedRequest.enqueue(github_installation, payload)
+    assert job.args == %{encoded: "g3QAAAABbQAAAAVoZWxsb20AAAAFd29ybGQ="}
+  end
+
   describe "perform/1" do
-    test "with complete run" do
+    test "with expired auth" do
       github_installation_authorization =
         insert(:github_installation_authorization, %{
-          rate_limit_remaining: 7000,
-          rate_limit_resets_at: ~U[2020-10-27 12:21:41Z]
+          rate_limit_last_updated_at: DateTime.utc_now(),
+          rate_limit_remaining: 500,
+          rate_limit_resets_at: ~U[2018-11-15 10:00:00Z]
         })
+
+      github_installation = github_installation_authorization.github_installation
 
       client = Github.Api.Client.new("1234", "token")
       request = Github.Api.V3.Installation.Repositories.read(client)
@@ -26,13 +43,35 @@ defmodule Astoria.Jobs.GithubSync.InstallationAuthorizedRequestTest do
       encoded =
         %{
           callback: &callback/2,
-          github_installation_authorization_id: github_installation_authorization.id,
-          job: Astoria.Jobs.GithubSync.InstallationAuthorizedRequest,
+          github_installation_id: github_installation.id,
+          request: request
+        }
+        |> Utility.serialise()
+
+      assert {:ok, :rate_expiry_requeue} ==
+               InstallationAuthorizedRequest.perform(%Oban.Job{args: %{"encoded" => encoded}})
+
+      assert_enqueued(worker: Astoria.Jobs.GithubSync.InstallationAuthorizedRequest)
+    end
+
+    test "with additional results, no existing auth" do
+      github_installation = insert(:github_installation)
+
+      client = Github.Api.Client.new("1234", "token")
+      request = Github.Api.V3.Installation.Repositories.read(client)
+
+      encoded =
+        %{
+          callback: &callback/2,
+          github_installation_id: github_installation.id,
           request: request
         }
         |> Utility.serialise()
 
       HTTPoisonMock
+      |> expect(:post, fn _path, _payload, _headers ->
+        {:ok, Fixtures.Github.Api.V3.App.Installations.AccessTokens.create()}
+      end)
       |> expect(:get, fn _path, _headers ->
         {:ok, Fixtures.Github.Api.V3.Installation.Repositories.read()}
       end)


### PR DESCRIPTION
Improvements to the way we handle resource limits and scheduling jobs when interacting with the GitHub API. Will allow using the full 24 hour period to download a full sync of a repo.